### PR TITLE
Omitting gemspec check in Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,7 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
     - 'scholarsphere-client.gemspec'
+
+Gemspec/RequiredRubyVersion:
+  Exclude:
+    - 'scholarsphere-client.gemspec'


### PR DESCRIPTION
This happened when updating the Rubocop gem.