### PR TITLE
Support uploading with presigned urls

### DIFF
--- a/lib/scholarsphere/client.rb
+++ b/lib/scholarsphere/client.rb
@@ -7,6 +7,7 @@ require 'scholarsphere/s3'
 require 'scholarsphere/client/config'
 require 'scholarsphere/client/ingest'
 require 'scholarsphere/client/collection'
+require 'scholarsphere/client/upload'
 require 'scholarsphere/client/version'
 
 module Scholarsphere

--- a/lib/scholarsphere/client/upload.rb
+++ b/lib/scholarsphere/client/upload.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Scholarsphere
+  module Client
+    class Upload
+      attr_reader :file
+
+      # @param [UploadedFile] file
+      def self.create(file:)
+        Scholarsphere::Client.connection.post do |req|
+          req.url 'uploads'
+          req.body = { key: file.key }.to_json
+        end
+      end
+    end
+  end
+end

--- a/lib/scholarsphere/s3.rb
+++ b/lib/scholarsphere/s3.rb
@@ -4,6 +4,7 @@ require 'aws-sdk-s3'
 
 module Scholarsphere
   module S3
+    require_relative 's3/presigned_uploader'
     require_relative 's3/uploader'
     require_relative 's3/uploaded_file'
   end

--- a/lib/scholarsphere/s3/presigned_uploader.rb
+++ b/lib/scholarsphere/s3/presigned_uploader.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# @abstract Uploads a single file to an S3 instance using a presigned url. The url is generated with a call to
+# Scholarsphere.
+
+module Scholarsphere
+  module S3
+    class PresignedUploader
+      attr_reader :file, :content_md5, :url
+
+      # @param [UploadedFile] file
+      def initialize(file:)
+        @file = file
+        @content_md5 = file.content_md5
+        @url = URI.parse(file.presigned_url)
+      end
+
+      # @return [Faraday::Response]
+      def upload
+        connection.put do |req|
+          req.body = file.source.read
+          req.headers['Content-MD5'] = file.content_md5
+        end
+      end
+
+      private
+
+        def connection
+          @connection ||= Faraday::Connection.new(
+            url: url,
+            ssl: { verify: Scholarsphere::Client.verify_ssl? }
+          )
+        end
+    end
+  end
+end

--- a/lib/scholarsphere/s3/uploaded_file.rb
+++ b/lib/scholarsphere/s3/uploaded_file.rb
@@ -52,6 +52,13 @@ module Scholarsphere
         source.size
       end
 
+      def presigned_url
+        body = JSON.parse(upload.body)
+        return body['url'] if upload.success?
+
+        raise Client::Error, body['message']
+      end
+
       private
 
         def metadata
@@ -64,6 +71,10 @@ module Scholarsphere
 
         def prefix
           ENV['SHRINE_CACHE_PREFIX'] || 'cache'
+        end
+
+        def upload
+          @upload ||= Client::Upload.create(file: self)
         end
     end
   end

--- a/spec/scholarsphere/client/upload_spec.rb
+++ b/spec/scholarsphere/client/upload_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe Scholarsphere::Client::Upload do
+  let(:upload) { described_class.create(file: file) }
+  let(:file) { instance_spy('Scholarsphere::S3::UploadedFile', key: key) }
+
+  describe '#create' do
+    context 'with a valid key' do
+      let(:key) { 'prefix/id' }
+
+      it 'returns a presigned url using the supplied key' do
+        expect(upload).to be_success
+        expect(upload.body).to include(key)
+      end
+    end
+
+    context 'with an invalid key' do
+      let(:key) { '' }
+
+      it 'returns an error response' do
+        expect(upload).not_to be_success
+        expect(upload.body).to include('Bad request')
+      end
+    end
+  end
+end

--- a/spec/scholarsphere/s3/presigned_uploader_spec.rb
+++ b/spec/scholarsphere/s3/presigned_uploader_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'scholarsphere/s3'
+
+RSpec.describe Scholarsphere::S3::PresignedUploader do
+  let(:path) { fixture_path('image.png') }
+  let(:file) { Scholarsphere::S3::UploadedFile.new(path) }
+  let(:checksum) { Digest::MD5.hexdigest(path.read) }
+
+  # Use an authenticated client to check if the presigned uploads were successful.
+  let(:client) do
+    Aws::S3::Client.new(
+      endpoint: ENV['S3_ENDPOINT'],
+      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      force_path_style: true,
+      region: ENV['AWS_REGION']
+    )
+  end
+
+  describe '#upload' do
+    context 'with the default options' do
+      let(:uploader) { described_class.new(file: file) }
+
+      it 'uploads the file to the bucket' do
+        response = uploader.upload
+        expect(response.status).to eq(200)
+        client_response = client.get_object(bucket: ENV['AWS_BUCKET'], key: file.key)
+        expect(Digest::MD5.hexdigest(client_response.body.read)).to eq(checksum)
+      end
+    end
+
+    context 'when providing a failing checksum' do
+      let(:uploader) { described_class.new(file: file) }
+      let(:file) { Scholarsphere::S3::UploadedFile.new(path, checksum: 'xxx') }
+
+      it 'uploads the file to the bucket' do
+        response = uploader.upload
+        expect(response.status).to eq(400)
+        expect(response.body).to include('BadDigest')
+      end
+    end
+  end
+end

--- a/spec/scholarsphere/s3/uploaded_file_spec.rb
+++ b/spec/scholarsphere/s3/uploaded_file_spec.rb
@@ -36,4 +36,23 @@ RSpec.describe Scholarsphere::S3::UploadedFile do
       )
     end
   end
+
+  describe '#presigned_url' do
+    context 'with a valid key' do
+      its(:presigned_url) { is_expected.to include('scholarsphere-dev/cache') }
+    end
+
+    context 'with an invalid key' do
+      let(:mock_upload) { instance_spy('Faraday::Response', success?: false, body: body) }
+      let(:body) { '{"message":"Bad request","errors":["param is missing or the value is empty: key"]}' }
+
+      before { allow(Scholarsphere::Client::Upload).to receive(:create).and_return(mock_upload) }
+
+      it 'raises an error' do
+        expect { file.presigned_url }.to raise_error(
+          Scholarsphere::Client::Error, 'Bad request'
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds S3::PresignedUploader to upload files to Scholarsphere via presigned urls. A request is sent to Scholarsphere for a url to upload data that doesn't require additional AWS credentials. Once the url is returned, the file can be uploaded to the bucket, which includes a prefix subdirectory. After the file is successfully uploaded, additional requests can be sent to ingest the file and its associated metadata into the Scholarsphere repository.