### PR TITLE
Support uploading with presigned urls

### DIFF
--- a/lib/scholarsphere/client.rb
+++ b/lib/scholarsphere/client.rb
@@ -7,6 +7,7 @@ require 'scholarsphere/s3'
 require 'scholarsphere/client/config'
 require 'scholarsphere/client/ingest'
 require 'scholarsphere/client/collection'
+require 'scholarsphere/client/upload'
 require 'scholarsphere/client/version'
 
 module Scholarsphere

--- a/lib/scholarsphere/client/ingest.rb
+++ b/lib/scholarsphere/client/ingest.rb
@@ -29,22 +29,18 @@ module Scholarsphere
         def build_content_hash(files)
           files.map do |file|
             if file.is_a?(Hash)
-              file.merge(file: S3::UploadedFile.new(file.fetch(:file)))
+              file.merge(file: S3::UploadedFile.new(source: file.fetch(:file)))
             else
-              { file: S3::UploadedFile.new(file) }
+              { file: S3::UploadedFile.new(source: file) }
             end
           end
         end
 
         def upload_files
           content.map do |file_parameters|
-            uploader.upload(file_parameters.fetch(:file))
-            file_parameters[:file] = file_parameters[:file].to_shrine.to_json
+            S3::Uploader.new(file: file_parameters.fetch(:file)).upload
+            file_parameters[:file] = file_parameters[:file].to_param.to_json
           end
-        end
-
-        def uploader
-          @uploader ||= S3::Uploader.new
         end
 
         def connection

--- a/lib/scholarsphere/client/upload.rb
+++ b/lib/scholarsphere/client/upload.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Scholarsphere
+  module Client
+    ##
+    #
+    # Requests a pre-signed url, id, and prefix from Scholarsphere for uploading a given file. In order to generate a
+    # correct path, the file's extension name is required for the request. The url is used to upload the file's binary
+    # content into Scholarsphere, while the id and key are used when adding the file to a work.
+    #
+    class Upload
+      # @param extname [String] Extension of the file to be uploaded, without the period, such as 'pdf'
+      def initialize(extname:)
+        @extname = extname
+      end
+
+      # @return [String] Prefix where the file is stored in the S3 bucket.
+      def prefix
+        data['prefix']
+      end
+
+      # @return [String] URL for uploading the file into AWS.
+      def url
+        data['url']
+      end
+
+      # @return [String] A unique identifier for the file which will serve as its name in S3.
+      def id
+        data['id']
+      end
+
+      private
+
+        attr_reader :extname
+
+        def request
+          @request ||= Scholarsphere::Client.connection.post do |req|
+            req.url 'uploads'
+            req.body = { extension: extname }.to_json
+          end
+        end
+
+        def data
+          @data ||= begin
+                      raise Client::Error unless request.success?
+
+                      JSON.parse(request.body)
+                    end
+        end
+    end
+  end
+end

--- a/spec/scholarsphere/client/upload_spec.rb
+++ b/spec/scholarsphere/client/upload_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe Scholarsphere::Client::Upload do
+  let(:upload) { described_class.new(extname: extname) }
+  let(:response) { JSON.parse(upload.body) }
+
+  describe '#create' do
+    context 'with a valid extension' do
+      let(:extname) { 'pdf' }
+
+      it 'returns the data' do
+        expect(upload.url).to include(extname)
+        expect(upload.id).to end_with(extname)
+        expect(upload.prefix).to eq('cache')
+      end
+    end
+
+    context 'with a missing extension' do
+      let(:extname) { '' }
+
+      it 'returns an error response' do
+        expect { upload.url }.to raise_error(Scholarsphere::Client::Error)
+      end
+    end
+  end
+end

--- a/spec/scholarsphere/s3/uploaded_file_spec.rb
+++ b/spec/scholarsphere/s3/uploaded_file_spec.rb
@@ -3,13 +3,29 @@
 require 'scholarsphere/s3'
 
 RSpec.describe Scholarsphere::S3::UploadedFile do
-  subject(:file) { described_class.new(source) }
+  subject(:file) { described_class.new(source: source) }
 
   let(:source) { fixture_path('image.png') }
 
-  its(:source) { is_expected.to eq(source) }
-  its(:id) { is_expected.to match(/^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}\.png$/) }
-  its(:key) { is_expected.to eq("cache/#{file.id}") }
+  describe '#source' do
+    subject { file.source }
+
+    it { is_expected.to be_a(Pathname) }
+  end
+
+  describe '#to_param' do
+    let(:params) { file.to_param }
+
+    it 'returns a hash of required parameters' do
+      expect(params[:id]).to match(/^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}\.png$/)
+      expect(params[:storage]).to eq('cache')
+      expect(params[:metadata]).to eq(
+        size: source.size,
+        filename: 'image.png',
+        mime_type: 'image/png'
+      )
+    end
+  end
 
   describe '#content_md5' do
     context 'when the digest is calculated' do
@@ -17,23 +33,15 @@ RSpec.describe Scholarsphere::S3::UploadedFile do
     end
 
     context 'when providing an existing md5 checksum' do
-      subject(:file) { described_class.new(source, checksum: Digest::MD5.hexdigest(source.read)) }
+      subject(:file) { described_class.new(source: source, checksum: Digest::MD5.hexdigest(source.read)) }
 
       its(:content_md5) { is_expected.to eq(Digest::MD5.base64digest(source.read)) }
     end
   end
 
-  describe '#to_shrine' do
-    let(:shrine_hash) { file.to_shrine }
+  describe '#presigned_url' do
+    subject { file.presigned_url }
 
-    it 'returns a hash for uploading to Shrine' do
-      expect(shrine_hash[:id]).to eq(file.id)
-      expect(shrine_hash[:storage]).to eq('cache')
-      expect(shrine_hash[:metadata]).to eq(
-        size: source.size,
-        filename: 'image.png',
-        mime_type: 'image/png'
-      )
-    end
+    it { is_expected.to include('scholarsphere-dev/cache') }
   end
 end

--- a/spec/scholarsphere/s3/uploader_spec.rb
+++ b/spec/scholarsphere/s3/uploader_spec.rb
@@ -3,92 +3,23 @@
 require 'scholarsphere/s3'
 
 RSpec.describe Scholarsphere::S3::Uploader do
-  let(:uploader) { described_class.new }
-
-  it { is_expected.to be_a(Aws::S3::FileUploader) }
-
-  describe '#multipart_threshold' do
-    context 'without modification' do
-      its(:multipart_threshold) { is_expected.to eq(Aws::S3::FileUploader::FIFTEEN_MEGABYTES) }
-    end
-
-    context 'when set to a custom value' do
-      subject { described_class.new(multipart_threshold: 1024) }
-
-      its(:multipart_threshold) { is_expected.to eq(1024) }
-    end
-  end
+  let(:path) { fixture_path('image.png') }
+  let(:uploader) { described_class.new(file: file) }
 
   describe '#upload' do
-    let(:path) { fixture_path('image.png') }
-    let(:file) { Scholarsphere::S3::UploadedFile.new(path) }
-    let(:checksum) { Digest::MD5.hexdigest(path.read) }
+    subject { uploader.upload }
 
-    context 'when using the default options' do
-      it 'adds the file to the S3 bucket' do
-        uploader.upload(file)
-        response = uploader.client.get_object(bucket: ENV['AWS_BUCKET'], key: file.key)
-        expect(Digest::MD5.hexdigest(response.body.read)).to eq(checksum)
-      end
+    context 'with the default options' do
+      let(:file) { Scholarsphere::S3::UploadedFile.new(source: path) }
+
+      its(:status) { is_expected.to eq(200) }
     end
 
-    context 'when using multipart upload' do
-      let(:path) { fixture_path('multipart.dat') }
-      let(:file) { Scholarsphere::S3::UploadedFile.new(path) }
-      let(:uploader) { described_class.new(multipart_threshold: file.size - 1024) }
+    context 'when providing a failing checksum' do
+      let(:file) { Scholarsphere::S3::UploadedFile.new(source: path, checksum: 'xxx') }
 
-      it 'adds the file to S3 using multipart upload' do
-        expect(uploader.multipart_threshold).to eq(file.size - 1024)
-        uploader.upload(file)
-        response = uploader.client.get_object(bucket: ENV['AWS_BUCKET'], key: file.key)
-        expect(Digest::MD5.hexdigest(response.body.read)).to eq(checksum)
-      end
-    end
-
-    context 'when the file exceeds the multipart upload threshold' do
-      let(:file) do
-        instance_spy(Scholarsphere::S3::UploadedFile,
-                     source: path,
-                     key: 'fakekey.txt',
-                     size: uploader.multipart_threshold + 1_024)
-      end
-
-      it 'does NOT send the MD5 hash' do
-        uploader.upload(file)
-        expect(file).not_to have_received(:content_md5)
-      end
-    end
-
-    # @note This tests the multipart brach of our upload method, but we still don't have a complete integration test
-    # that verifies a multipart upload. Perhaps that's overkill?
-    context 'when forcing multipart upload on a small file' do
-      let(:uploader) { described_class.new(multipart_threshold: 1) }
-
-      it 'adds the file to the S3 bucket' do
-        expect do
-          uploader.upload(file)
-        end.to raise_error(ArgumentError, 'unable to multipart upload files smaller than 5MB')
-      end
-    end
-
-    context 'when providing a passing md5 hash' do
-      let(:file) { Scholarsphere::S3::UploadedFile.new(path, checksum: checksum) }
-
-      it 'fails the upload with an error' do
-        uploader.upload(file)
-        response = uploader.client.get_object(bucket: ENV['AWS_BUCKET'], key: file.key)
-        expect(Digest::MD5.hexdigest(response.body.read)).to eq(checksum)
-      end
-    end
-
-    context 'when providing a failing md5 hash' do
-      let(:file) { Scholarsphere::S3::UploadedFile.new(path, checksum: 'xxx') }
-
-      it 'fails the upload with an error' do
-        expect do
-          uploader.upload(file)
-        end.to raise_error(Aws::S3::Errors::BadDigest, 'The Content-Md5 you specified did not match what we received.')
-      end
+      its(:status) { is_expected.to eq(400) }
+      its(:body) { is_expected.to include('BadDigest') }
     end
   end
 end


### PR DESCRIPTION
Drops support for the current multipart uploader in favor of using presigned urls exclusively.

A request is sent to Scholarsphere for a url to upload data that doesn't require additional AWS credentials. Once the url is returned, the file can be uploaded to the bucket, which includes a prefix subdirectory. After the file is successfully uploaded, additional requests can be sent to ingest the file and its associated metadata into the Scholarsphere repository.

Note that this uploader does _not_ support multipart uploading. That will be re-implemented at a later date using the same presigned url approach.

Related to https://github.com/psu-stewardship/scholarsphere/issues/815