### PR TITLE
Updating spec tests to align with 4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: "RSpec"
           command: bundle exec rspec
           environment:
-            SS4_ENDPOINT: "http://scholarsphere.test/api/v1"
+            SS4_ENDPOINT: "https://scholarsphere.test/api/v1"
       - run:
           name: "Copy VCR Logs"
           when: on_fail

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,6 @@ Metrics/BlockLength:
 Gemspec/RequiredRubyVersion:
   Exclude:
     - 'scholarsphere-client.gemspec'
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/lib/scholarsphere/client.rb
+++ b/lib/scholarsphere/client.rb
@@ -28,6 +28,10 @@ module Scholarsphere
         )
       end
 
+      def reset
+        @connection = nil
+      end
+
       def verify_ssl?
         ENV['SS_CLIENT_SSL'] != 'false'
       end

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_Client_Collection/_create/creates_a_new_collection_in_Scholarsphere.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_Client_Collection/_create/creates_a_new_collection_in_Scholarsphere.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/collections
+    uri: https://scholarsphere.test/api/v1/collections
     body:
       encoding: UTF-8
       string: '{"metadata":{"title":"Sample Title","creator_aliases_attributes":[{"alias":"John
@@ -28,7 +28,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"fb30dffde5c5f0a407f1195e499c88e1"
+      - W/"83e333ad0ebebee1634fbe0893fd4e10"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -40,17 +40,17 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 0ded7963-81ad-4110-95db-83863bbdc844
+      - 38f5e79a-b7e6-4ccd-a916-06f58f3d7411
       X-Runtime:
-      - '0.054835'
+      - '0.197003'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:46:06 GMT
+      - Wed, 03 Mar 2021 20:00:27 GMT
       Content-Length:
       - '105'
     body:
       encoding: UTF-8
-      string: '{"message":"Collection was successfully created","url":"/resources/4f0f6499-6edb-4874-a08d-0dbddb044c6d"}'
-  recorded_at: Mon, 18 Jan 2021 15:46:06 GMT
+      string: '{"message":"Collection was successfully created","url":"/resources/109a2047-2af7-4706-92e4-e890b0161fea"}'
+  recorded_at: Wed, 03 Mar 2021 20:00:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_Client_Ingest/_publish/with_an_array_of_files/publishes_new_works_into_Scholarsphere.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_Client_Ingest/_publish/with_an_array_of_files/publishes_new_works_into_Scholarsphere.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/uploads
+    uri: https://scholarsphere.test/api/v1/uploads
     body:
       encoding: UTF-8
       string: '{"extension":".png"}'
@@ -27,7 +27,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"f0dd8bea1404b970173e75fbfec10ac9"
+      - W/"c2723823d6f1d4f42b84ad8f99edebee"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -39,25 +39,25 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - df4eb28c-e3f8-4958-b0d6-67aa0e5aaa81
+      - 1ead4b9f-af66-41dd-ae62-f8838d65c11a
       X-Runtime:
-      - '0.008227'
+      - '0.011842'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:50:26 GMT
+      - Wed, 03 Mar 2021 19:56:33 GMT
       Content-Length:
-      - '436'
+      - '445'
     body:
       encoding: UTF-8
-      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/7d337014-1b1b-40c9-8201-f0b613b02ec3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=asdf%2F20210118%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210118T155026Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=64911fffa8cd18449a8af3387f3aa35deaa55a15dffb5826d2c8848a453256f2","id":"7d337014-1b1b-40c9-8201-f0b613b02ec3.png","prefix":"cache"}'
-  recorded_at: Mon, 18 Jan 2021 15:50:26 GMT
+      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/9f5431e2-778d-47ed-b371-d23e97d249ce.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=scholarsphere%2F20210303%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210303T195633Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=d7773bf923c73e3bc467a4081d4c964de7eb166c3a052300369d3a508fd0d06c","id":"9f5431e2-778d-47ed-b371-d23e97d249ce.png","prefix":"cache"}'
+  recorded_at: Wed, 03 Mar 2021 19:56:33 GMT
 - request:
     method: put
-    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/7d337014-1b1b-40c9-8201-f0b613b02ec3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=asdf/20210118/us-east-1/s3/aws4_request&X-Amz-Date=20210118T155026Z&X-Amz-Expires=900&X-Amz-Signature=64911fffa8cd18449a8af3387f3aa35deaa55a15dffb5826d2c8848a453256f2&X-Amz-SignedHeaders=host
+    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/9f5431e2-778d-47ed-b371-d23e97d249ce.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=scholarsphere/20210303/us-east-1/s3/aws4_request&X-Amz-Date=20210303T195633Z&X-Amz-Expires=900&X-Amz-Signature=d7773bf923c73e3bc467a4081d4c964de7eb166c3a052300369d3a508fd0d06c&X-Amz-SignedHeaders=host
     body:
       encoding: UTF-8
-      base64_string: image-content
+      base64_string: 'imagecontent'
     headers:
       User-Agent:
       - Faraday v1.0.1
@@ -87,18 +87,18 @@ http_interactions:
       Vary:
       - Origin
       X-Amz-Request-Id:
-      - 165B5E58BE8D0A90
+      - 1668ED4FED2A188C
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:50:26 GMT
+      - Wed, 03 Mar 2021 19:56:33 GMT
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Mon, 18 Jan 2021 15:50:26 GMT
+  recorded_at: Wed, 03 Mar 2021 19:56:33 GMT
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/uploads
+    uri: https://scholarsphere.test/api/v1/uploads
     body:
       encoding: UTF-8
       string: '{"extension":".pdf"}'
@@ -123,7 +123,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"85471fe322f9e093e53dfb69b96f337b"
+      - W/"1d09d9d79587818b4076f7f9f99ff978"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -135,25 +135,25 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - dcb2702a-ab2b-4376-863b-d74d05394d20
+      - 4d29c184-08db-4760-ad8d-5fd9597663ff
       X-Runtime:
-      - '0.007692'
+      - '0.007482'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:50:26 GMT
+      - Wed, 03 Mar 2021 19:56:33 GMT
       Content-Length:
-      - '436'
+      - '445'
     body:
       encoding: UTF-8
-      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/dfc0aecb-f2cc-45bf-b1df-be20a5a1c37a.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=asdf%2F20210118%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210118T155026Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=bc7194141785c18cc72c6a071bc30896f0d583b2a43a176ce82c3bd0518fb1e8","id":"dfc0aecb-f2cc-45bf-b1df-be20a5a1c37a.pdf","prefix":"cache"}'
-  recorded_at: Mon, 18 Jan 2021 15:50:26 GMT
+      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/effb3cd6-5082-4da0-88ea-5ac5144adbf6.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=scholarsphere%2F20210303%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210303T195633Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=3d8eab6659d8679af562d3e469173d891d2496fae7f7131374eaf2112b43bdb9","id":"effb3cd6-5082-4da0-88ea-5ac5144adbf6.pdf","prefix":"cache"}'
+  recorded_at: Wed, 03 Mar 2021 19:56:33 GMT
 - request:
     method: put
-    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/dfc0aecb-f2cc-45bf-b1df-be20a5a1c37a.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=asdf/20210118/us-east-1/s3/aws4_request&X-Amz-Date=20210118T155026Z&X-Amz-Expires=900&X-Amz-Signature=bc7194141785c18cc72c6a071bc30896f0d583b2a43a176ce82c3bd0518fb1e8&X-Amz-SignedHeaders=host
+    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/effb3cd6-5082-4da0-88ea-5ac5144adbf6.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=scholarsphere/20210303/us-east-1/s3/aws4_request&X-Amz-Date=20210303T195633Z&X-Amz-Expires=900&X-Amz-Signature=3d8eab6659d8679af562d3e469173d891d2496fae7f7131374eaf2112b43bdb9&X-Amz-SignedHeaders=host
     body:
       encoding: UTF-8
-      base64_string: image-content
+      base64_string: 'imagecontent'
     headers:
       User-Agent:
       - Faraday v1.0.1
@@ -183,22 +183,22 @@ http_interactions:
       Vary:
       - Origin
       X-Amz-Request-Id:
-      - 165B5E58C0F09B1C
+      - 1668ED4FEF9E85E4
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:50:27 GMT
+      - Wed, 03 Mar 2021 19:56:33 GMT
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Mon, 18 Jan 2021 15:50:26 GMT
+  recorded_at: Wed, 03 Mar 2021 19:56:33 GMT
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/ingest
+    uri: https://scholarsphere.test/api/v1/ingest
     body:
       encoding: UTF-8
-      string: '{"metadata":{"title":"Sample Title","creator_aliases_attributes":[{"alias":"John
-        Doe","actor_attributes":{"email":"jxd21@psu.edu","given_name":"John","surname":"Doe","psu_id":"jxd21"}}]},"content":[{"file":"{\"id\":\"7d337014-1b1b-40c9-8201-f0b613b02ec3.png\",\"storage\":\"cache\",\"metadata\":{\"size\":63960,\"filename\":\"image.png\",\"mime_type\":\"image/png\"}}"},{"file":"{\"id\":\"dfc0aecb-f2cc-45bf-b1df-be20a5a1c37a.pdf\",\"storage\":\"cache\",\"metadata\":{\"size\":16798,\"filename\":\"ipsum.pdf\",\"mime_type\":\"application/pdf\"}}"}],"depositor":{"email":"jxd21@psu.edu","given_name":"John","surname":"Doe","psu_id":"jxd21"},"permissions":{}}'
+      string: '{"metadata":{"title":"Sample Title","creators_attributes":[{"display_name":"Dan
+        Coughlin","actor_attributes":{"psu_id":"dmc186","surname":"Coughlin","given_name":"Dan","email":"dmc186@psu.edu"}}]},"content":[{"file":"{\"id\":\"9f5431e2-778d-47ed-b371-d23e97d249ce.png\",\"storage\":\"cache\",\"metadata\":{\"size\":63960,\"filename\":\"image.png\",\"mime_type\":\"image/png\"}}"},{"file":"{\"id\":\"effb3cd6-5082-4da0-88ea-5ac5144adbf6.pdf\",\"storage\":\"cache\",\"metadata\":{\"size\":16798,\"filename\":\"ipsum.pdf\",\"mime_type\":\"application/pdf\"}}"}],"depositor":{"psu_id":"agw13","surname":"Wead","given_name":"Adam","email":"agw13@psu.edu"},"permissions":{}}'
     headers:
       Content-Type:
       - application/json
@@ -220,7 +220,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"31d36a94ed4ac037b3936c6988e06eff"
+      - W/"5db7b28c570a22f4527766f50579b57c"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -232,17 +232,17 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 27c7318c-81b8-4401-8bff-b8265bbb2752
+      - 5158485d-31c4-441a-b722-bfbb766857a3
       X-Runtime:
-      - '0.194404'
+      - '0.215453'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:50:27 GMT
+      - Wed, 03 Mar 2021 19:56:34 GMT
       Content-Length:
       - '99'
     body:
       encoding: UTF-8
-      string: '{"message":"Work was successfully created","url":"/resources/393ea1d0-5b2b-4a05-993c-6a7d14c9a022"}'
-  recorded_at: Mon, 18 Jan 2021 15:50:27 GMT
+      string: '{"message":"Work was successfully created","url":"/resources/0797e99c-7d4f-4e05-8bf6-86aea1029a6a"}'
+  recorded_at: Wed, 03 Mar 2021 19:56:34 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_Client_Ingest/_publish/with_an_array_of_hashes_specifying_the_deposit_date/publishes_the_file_with_its_additional_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_Client_Ingest/_publish/with_an_array_of_hashes_specifying_the_deposit_date/publishes_the_file_with_its_additional_metadata.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/uploads
+    uri: https://scholarsphere.test/api/v1/uploads
     body:
       encoding: UTF-8
       string: '{"extension":".png"}'
@@ -27,7 +27,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"05fe8bcfe002993110c522e62944b82c"
+      - W/"c8134d455290bfb93003976dab3ac19e"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -39,25 +39,25 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 56cb70fb-07f6-418b-a057-8f5ba934088f
+      - 61630ddb-b98c-4f1f-8659-43a4bdc942b4
       X-Runtime:
-      - '0.024040'
+      - '0.038050'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:50:27 GMT
+      - Wed, 03 Mar 2021 19:56:34 GMT
       Content-Length:
-      - '436'
+      - '445'
     body:
       encoding: UTF-8
-      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/2c6b6f30-280c-4126-af21-8325db94cc71.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=asdf%2F20210118%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210118T155027Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=76bd006da99af0b0510ff0c39133c445d758529bbbe90669b48bfc333b8ceaeb","id":"2c6b6f30-280c-4126-af21-8325db94cc71.png","prefix":"cache"}'
-  recorded_at: Mon, 18 Jan 2021 15:50:27 GMT
+      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/8e93babf-46bb-409d-a906-b296a0482c7a.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=scholarsphere%2F20210303%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210303T195634Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=a97c69943ae98dce92feb89fd65bf0fcde8cd0c3f6f703c5f28698c91c6c5e43","id":"8e93babf-46bb-409d-a906-b296a0482c7a.png","prefix":"cache"}'
+  recorded_at: Wed, 03 Mar 2021 19:56:34 GMT
 - request:
     method: put
-    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/2c6b6f30-280c-4126-af21-8325db94cc71.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=asdf/20210118/us-east-1/s3/aws4_request&X-Amz-Date=20210118T155027Z&X-Amz-Expires=900&X-Amz-Signature=76bd006da99af0b0510ff0c39133c445d758529bbbe90669b48bfc333b8ceaeb&X-Amz-SignedHeaders=host
+    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/8e93babf-46bb-409d-a906-b296a0482c7a.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=scholarsphere/20210303/us-east-1/s3/aws4_request&X-Amz-Date=20210303T195634Z&X-Amz-Expires=900&X-Amz-Signature=a97c69943ae98dce92feb89fd65bf0fcde8cd0c3f6f703c5f28698c91c6c5e43&X-Amz-SignedHeaders=host
     body:
       encoding: UTF-8
-      base64_string: image-content
+      base64_string: 'imagecontent'
     headers:
       User-Agent:
       - Faraday v1.0.1
@@ -87,22 +87,22 @@ http_interactions:
       Vary:
       - Origin
       X-Amz-Request-Id:
-      - 165B5E58CFF94230
+      - 1668ED500121506C
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:50:27 GMT
+      - Wed, 03 Mar 2021 19:56:34 GMT
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Mon, 18 Jan 2021 15:50:27 GMT
+  recorded_at: Wed, 03 Mar 2021 19:56:34 GMT
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/ingest
+    uri: https://scholarsphere.test/api/v1/ingest
     body:
       encoding: UTF-8
-      string: '{"metadata":{"title":"Array of Hashes for Files","creator_aliases_attributes":[{"alias":"John
-        Doe","actor_attributes":{"email":"jxd21@psu.edu","given_name":"John","surname":"Doe","psu_id":"jxd21"}}]},"content":[{"file":"{\"id\":\"2c6b6f30-280c-4126-af21-8325db94cc71.png\",\"storage\":\"cache\",\"metadata\":{\"size\":63960,\"filename\":\"image.png\",\"mime_type\":\"image/png\"}}","deposited_at":"2012-05-16T00:00:00+00:00"}],"depositor":{"email":"jxd21@psu.edu","given_name":"John","surname":"Doe","psu_id":"jxd21"},"permissions":{}}'
+      string: '{"metadata":{"title":"Array of Hashes for Files","creators_attributes":[{"display_name":"Dan
+        Coughlin","actor_attributes":{"psu_id":"dmc186","surname":"Coughlin","given_name":"Dan","email":"dmc186@psu.edu"}}]},"content":[{"file":"{\"id\":\"8e93babf-46bb-409d-a906-b296a0482c7a.png\",\"storage\":\"cache\",\"metadata\":{\"size\":63960,\"filename\":\"image.png\",\"mime_type\":\"image/png\"}}","deposited_at":"2012-05-16T00:00:00+00:00"}],"depositor":{"psu_id":"agw13","surname":"Wead","given_name":"Adam","email":"agw13@psu.edu"},"permissions":{}}'
     headers:
       Content-Type:
       - application/json
@@ -124,7 +124,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"d64687b7925e6d37c7e8e8eba69c3863"
+      - W/"f92fd8cd039b57472e8b229f97832273"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -136,17 +136,17 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 239c464a-875c-4284-a5b7-f405899d9f25
+      - 6fb51f09-7cfa-4078-8659-a67f2485787e
       X-Runtime:
-      - '0.164415'
+      - '0.127356'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:50:27 GMT
+      - Wed, 03 Mar 2021 19:56:34 GMT
       Content-Length:
       - '99'
     body:
       encoding: UTF-8
-      string: '{"message":"Work was successfully created","url":"/resources/1ede5493-ca4e-43f1-ad2f-24978a26b47e"}'
-  recorded_at: Mon, 18 Jan 2021 15:50:27 GMT
+      string: '{"message":"Work was successfully created","url":"/resources/c0a13467-5f00-4c79-a822-eeb229ccb4be"}'
+  recorded_at: Wed, 03 Mar 2021 19:56:34 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_Client_Upload/_create/with_a_missing_extension/returns_an_error_response.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_Client_Upload/_create/with_a_missing_extension/returns_an_error_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/uploads
+    uri: https://scholarsphere.test/api/v1/uploads
     body:
       encoding: UTF-8
       string: '{"extension":""}'
@@ -37,17 +37,18 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 7d313435-2759-4ad7-871c-4a9cade4b52c
+      - 4db54d9f-5878-4a97-95ec-cc60c90f40cd
       X-Runtime:
-      - '0.008204'
+      - '0.007340'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:51:46 GMT
+      - Wed, 03 Mar 2021 20:00:27 GMT
       Content-Length:
       - '88'
     body:
       encoding: UTF-8
-      string: '{"message":"Bad request","errors":["param is missing or the value is empty: extension"]}'
-  recorded_at: Mon, 18 Jan 2021 15:51:46 GMT
+      string: '{"message":"Bad request","errors":["param is missing or the value is
+        empty: extension"]}'
+  recorded_at: Wed, 03 Mar 2021 20:00:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_Client_Upload/_create/with_a_valid_extension/returns_the_data.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_Client_Upload/_create/with_a_valid_extension/returns_the_data.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/uploads
+    uri: https://scholarsphere.test/api/v1/uploads
     body:
       encoding: UTF-8
       string: '{"extension":"pdf"}'
@@ -27,7 +27,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"2a48de5209875f3dcd9a6a0c98d670c0"
+      - W/"14beb482b5de2ccca1f5a00a69d09c37"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -39,17 +39,17 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 8b1c1100-e4fb-4b48-9cca-be9ad01e89b1
+      - af6464a3-d0b8-4007-9159-a556ba291667
       X-Runtime:
-      - '0.008003'
+      - '0.009673'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:51:46 GMT
+      - Wed, 03 Mar 2021 20:00:27 GMT
       Content-Length:
-      - '436'
+      - '445'
     body:
       encoding: UTF-8
-      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/1006f615-16fc-4375-abfc-558c212e689f.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=asdf%2F20210118%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210118T155146Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=ae0bddf4f6f9628d8584c04d7a1e350eba7373a5721167201d252934f32400fd","id":"1006f615-16fc-4375-abfc-558c212e689f.pdf","prefix":"cache"}'
-  recorded_at: Mon, 18 Jan 2021 15:51:46 GMT
+      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/eb2334ef-bcc9-442f-a013-3d78567b83fa.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=scholarsphere%2F20210303%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210303T200027Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=b2448b93b61ddcc118395d5307288fa9a20225d7179c206b39bed55fb721e41c","id":"eb2334ef-bcc9-442f-a013-3d78567b83fa.pdf","prefix":"cache"}'
+  recorded_at: Wed, 03 Mar 2021 20:00:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_S3_UploadedFile/_presigned_url/1_4_1.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_S3_UploadedFile/_presigned_url/1_4_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/uploads
+    uri: https://scholarsphere.test/api/v1/uploads
     body:
       encoding: UTF-8
       string: '{"extension":".png"}'
@@ -27,7 +27,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"71d8ebd38031c69a77ce632d96070609"
+      - W/"5dc2b9afbbac6bfc5bb07fdf33ee5c9a"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -39,17 +39,17 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 5bad7453-2609-4db5-9d1a-3874a6e3e431
+      - 60cc7f2f-2199-42ed-bed5-8c3e7458768e
       X-Runtime:
-      - '0.008021'
+      - '0.008285'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:58:16 GMT
+      - Wed, 03 Mar 2021 20:00:27 GMT
       Content-Length:
-      - '436'
+      - '445'
     body:
       encoding: UTF-8
-      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/2c498bdd-5aa1-43a4-ab02-f4031b254a47.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=asdf%2F20210118%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210118T155816Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=2cb546e2fa5d73259af6f20a63e7e436da651286ba7a7e0b3980ef0caa702821","id":"2c498bdd-5aa1-43a4-ab02-f4031b254a47.png","prefix":"cache"}'
-  recorded_at: Mon, 18 Jan 2021 15:58:16 GMT
+      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/dccc11fd-4ad7-4b98-988d-0e8c7f1345fe.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=scholarsphere%2F20210303%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210303T200027Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=c64fbc3676e76a21cfef7c6462565feb4ad5095593a3eb2c9d417452ba8320f5","id":"dccc11fd-4ad7-4b98-988d-0e8c7f1345fe.png","prefix":"cache"}'
+  recorded_at: Wed, 03 Mar 2021 20:00:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_S3_UploadedFile/_to_param/returns_a_hash_of_required_parameters.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_S3_UploadedFile/_to_param/returns_a_hash_of_required_parameters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/uploads
+    uri: https://scholarsphere.test/api/v1/uploads
     body:
       encoding: UTF-8
       string: '{"extension":".png"}'
@@ -27,7 +27,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"c53ac684b9c138b6f8e8fa84765b07a6"
+      - W/"803f77a6e304ada55f1179a180223ce2"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -39,17 +39,17 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 4c639056-47e7-4342-a60f-593fafaa128f
+      - 66672ee7-2c5f-4693-8f4c-7d546b5b606d
       X-Runtime:
-      - '0.008962'
+      - '0.008331'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:56:47 GMT
+      - Wed, 03 Mar 2021 20:00:27 GMT
       Content-Length:
-      - '436'
+      - '445'
     body:
       encoding: UTF-8
-      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/38c3fd51-09a5-48bb-a611-ccf4f67249e2.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=asdf%2F20210118%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210118T155647Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=df091b9dde6d032e304edf5c6a7dec439a1b815f69dcf090b15b3881096df8de","id":"38c3fd51-09a5-48bb-a611-ccf4f67249e2.png","prefix":"cache"}'
-  recorded_at: Mon, 18 Jan 2021 15:56:47 GMT
+      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/21c04182-26b3-4c5b-b910-11ea6315bf30.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=scholarsphere%2F20210303%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210303T200027Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=6a935713877a472203973a8b4cd64e31bbe11f6b9756e7da6b35cf453035b525","id":"21c04182-26b3-4c5b-b910-11ea6315bf30.png","prefix":"cache"}'
+  recorded_at: Wed, 03 Mar 2021 20:00:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_S3_Uploader/_upload/when_providing_a_failing_checksum/body/1_1_2_2_1.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_S3_Uploader/_upload/when_providing_a_failing_checksum/body/1_1_2_2_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/uploads
+    uri: https://scholarsphere.test/api/v1/uploads
     body:
       encoding: UTF-8
       string: '{"extension":".png"}'
@@ -27,7 +27,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"189b9370123b2855b13acd4086c22bbd"
+      - W/"96b25d6ee3af37d5cf703fca4014de77"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -39,25 +39,25 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - fc2a1088-79b2-477c-b28b-dc147c38da28
+      - e3616c97-830d-457d-8083-c1fbe39fdfe5
       X-Runtime:
-      - '0.007735'
+      - '0.013325'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:55:19 GMT
+      - Wed, 03 Mar 2021 20:00:27 GMT
       Content-Length:
-      - '436'
+      - '445'
     body:
       encoding: UTF-8
-      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/7ec5e6c6-5644-4bf0-b8a3-8cef3c67763c.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=asdf%2F20210118%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210118T155519Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=35ea3285ae0ba190a916904d2671287369a8bd83f7a85cc44e45daa03c604c61","id":"7ec5e6c6-5644-4bf0-b8a3-8cef3c67763c.png","prefix":"cache"}'
-  recorded_at: Mon, 18 Jan 2021 15:55:19 GMT
+      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/6904ddaa-1240-48d0-b2b6-8b75654d7508.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=scholarsphere%2F20210303%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210303T200027Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=87b9e11b7f2ca07ac0b54cb943c791f4ae670e5a7d1677eb14fef14d45af8b0f","id":"6904ddaa-1240-48d0-b2b6-8b75654d7508.png","prefix":"cache"}'
+  recorded_at: Wed, 03 Mar 2021 20:00:27 GMT
 - request:
     method: put
-    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/7ec5e6c6-5644-4bf0-b8a3-8cef3c67763c.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=asdf/20210118/us-east-1/s3/aws4_request&X-Amz-Date=20210118T155519Z&X-Amz-Expires=900&X-Amz-Signature=35ea3285ae0ba190a916904d2671287369a8bd83f7a85cc44e45daa03c604c61&X-Amz-SignedHeaders=host
+    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/6904ddaa-1240-48d0-b2b6-8b75654d7508.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=scholarsphere/20210303/us-east-1/s3/aws4_request&X-Amz-Date=20210303T200027Z&X-Amz-Expires=900&X-Amz-Signature=87b9e11b7f2ca07ac0b54cb943c791f4ae670e5a7d1677eb14fef14d45af8b0f&X-Amz-SignedHeaders=host
     body:
       encoding: UTF-8
-      base64_string: image-content
+      base64_string: 'imagecontent'
     headers:
       User-Agent:
       - Faraday v1.0.1
@@ -87,15 +87,15 @@ http_interactions:
       Vary:
       - Origin
       X-Amz-Request-Id:
-      - 165B5E9CD2CF51F4
+      - 1668ED864A354D04
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:55:19 GMT
+      - Wed, 03 Mar 2021 20:00:27 GMT
     body:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <Error><Code>BadDigest</Code><Message>The Content-Md5 you specified did not match what we received.</Message><Key>cache/7ec5e6c6-5644-4bf0-b8a3-8cef3c67763c.png</Key><BucketName>scholarsphere-dev</BucketName><Resource>/scholarsphere-dev/cache/7ec5e6c6-5644-4bf0-b8a3-8cef3c67763c.png</Resource><RequestId>165B5E9CD2CF51F4</RequestId><HostId>ff55eeaa-9e90-46e2-9c0f-38a0ed91ddf6</HostId></Error>
-  recorded_at: Mon, 18 Jan 2021 15:55:19 GMT
+        <Error><Code>BadDigest</Code><Message>The Content-Md5 you specified did not match what we received.</Message><Key>cache/6904ddaa-1240-48d0-b2b6-8b75654d7508.png</Key><BucketName>scholarsphere-dev</BucketName><Resource>/scholarsphere-dev/cache/6904ddaa-1240-48d0-b2b6-8b75654d7508.png</Resource><RequestId>1668ED864A354D04</RequestId><HostId>09786e77-b9c1-49e5-a910-af4b329b638a</HostId></Error>
+  recorded_at: Wed, 03 Mar 2021 20:00:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_S3_Uploader/_upload/when_providing_a_failing_checksum/status/1_1_2_1_1.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_S3_Uploader/_upload/when_providing_a_failing_checksum/status/1_1_2_1_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/uploads
+    uri: https://scholarsphere.test/api/v1/uploads
     body:
       encoding: UTF-8
       string: '{"extension":".png"}'
@@ -27,7 +27,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"d82253eba0d9e1ccc16f3e4ab07c2ca4"
+      - W/"441184f83940c35e87d624cc99d1f5c8"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -39,25 +39,25 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - f12392ad-29ad-460c-b2c8-c2edff9bab45
+      - 5dcde188-1898-4d1d-bdaf-4146d1a0798b
       X-Runtime:
-      - '0.008582'
+      - '0.012292'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:55:19 GMT
+      - Wed, 03 Mar 2021 20:00:27 GMT
       Content-Length:
-      - '436'
+      - '445'
     body:
       encoding: UTF-8
-      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/b5244e6f-34b0-465c-a0e5-e878587de325.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=asdf%2F20210118%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210118T155519Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=3925494928fc6b63eb6ce07e07231870740f4a181676b47c318ddf255653f713","id":"b5244e6f-34b0-465c-a0e5-e878587de325.png","prefix":"cache"}'
-  recorded_at: Mon, 18 Jan 2021 15:55:19 GMT
+      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/81be1a7a-d3c1-4d11-ab18-fd2aea20ca6d.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=scholarsphere%2F20210303%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210303T200027Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=15d06d8e596fc842b733072cdcaff67cb4f9cf5b5850e4bee00b97d03777ad5b","id":"81be1a7a-d3c1-4d11-ab18-fd2aea20ca6d.png","prefix":"cache"}'
+  recorded_at: Wed, 03 Mar 2021 20:00:27 GMT
 - request:
     method: put
-    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/b5244e6f-34b0-465c-a0e5-e878587de325.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=asdf/20210118/us-east-1/s3/aws4_request&X-Amz-Date=20210118T155519Z&X-Amz-Expires=900&X-Amz-Signature=3925494928fc6b63eb6ce07e07231870740f4a181676b47c318ddf255653f713&X-Amz-SignedHeaders=host
+    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/81be1a7a-d3c1-4d11-ab18-fd2aea20ca6d.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=scholarsphere/20210303/us-east-1/s3/aws4_request&X-Amz-Date=20210303T200027Z&X-Amz-Expires=900&X-Amz-Signature=15d06d8e596fc842b733072cdcaff67cb4f9cf5b5850e4bee00b97d03777ad5b&X-Amz-SignedHeaders=host
     body:
       encoding: UTF-8
-      base64_string: image-content
+      base64_string: 'imagecontent'
     headers:
       User-Agent:
       - Faraday v1.0.1
@@ -87,15 +87,15 @@ http_interactions:
       Vary:
       - Origin
       X-Amz-Request-Id:
-      - 165B5E9CD0B73DA0
+      - 1668ED86467E02F0
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:55:19 GMT
+      - Wed, 03 Mar 2021 20:00:27 GMT
     body:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <Error><Code>BadDigest</Code><Message>The Content-Md5 you specified did not match what we received.</Message><Key>cache/b5244e6f-34b0-465c-a0e5-e878587de325.png</Key><BucketName>scholarsphere-dev</BucketName><Resource>/scholarsphere-dev/cache/b5244e6f-34b0-465c-a0e5-e878587de325.png</Resource><RequestId>165B5E9CD0B73DA0</RequestId><HostId>ff55eeaa-9e90-46e2-9c0f-38a0ed91ddf6</HostId></Error>
-  recorded_at: Mon, 18 Jan 2021 15:55:19 GMT
+        <Error><Code>BadDigest</Code><Message>The Content-Md5 you specified did not match what we received.</Message><Key>cache/81be1a7a-d3c1-4d11-ab18-fd2aea20ca6d.png</Key><BucketName>scholarsphere-dev</BucketName><Resource>/scholarsphere-dev/cache/81be1a7a-d3c1-4d11-ab18-fd2aea20ca6d.png</Resource><RequestId>1668ED86467E02F0</RequestId><HostId>09786e77-b9c1-49e5-a910-af4b329b638a</HostId></Error>
+  recorded_at: Wed, 03 Mar 2021 20:00:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_S3_Uploader/_upload/with_the_default_options/status/1_1_1_1_1.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_S3_Uploader/_upload/with_the_default_options/status/1_1_1_1_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://scholarsphere.test/api/v1/uploads
+    uri: https://scholarsphere.test/api/v1/uploads
     body:
       encoding: UTF-8
       string: '{"extension":".png"}'
@@ -27,7 +27,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"e03398fd064517fd4a444c386c9b0e74"
+      - W/"666f29ee520645c15bdf822d5f62f0d9"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Content-Type-Options:
@@ -39,25 +39,25 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - '08ba727c-1d0d-4255-b907-a088061d71bd'
+      - 5b818bb3-fcae-445a-aae4-22cdecc36dee
       X-Runtime:
-      - '0.007791'
+      - '0.012120'
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:55:19 GMT
+      - Wed, 03 Mar 2021 20:00:27 GMT
       Content-Length:
-      - '436'
+      - '445'
     body:
       encoding: UTF-8
-      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/b9a5c6b8-6a21-429d-bd67-a5af4a6912ef.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=asdf%2F20210118%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210118T155519Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=98143b79f47a524ec378e864e7ce265afbccb7f99a1a3da2cc0e91479602c119","id":"b9a5c6b8-6a21-429d-bd67-a5af4a6912ef.png","prefix":"cache"}'
-  recorded_at: Mon, 18 Jan 2021 15:55:19 GMT
+      string: '{"url":"http://127.0.0.1:9000/scholarsphere-dev/cache/a702c6a0-23a2-45ff-810f-185bb22ab2b6.png?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=scholarsphere%2F20210303%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210303T200027Z\u0026X-Amz-Expires=900\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=2909f6ce689cc790247995d920dbb1e4c1ba97fa1c7ee7ac766e56498597e019","id":"a702c6a0-23a2-45ff-810f-185bb22ab2b6.png","prefix":"cache"}'
+  recorded_at: Wed, 03 Mar 2021 20:00:27 GMT
 - request:
     method: put
-    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/b9a5c6b8-6a21-429d-bd67-a5af4a6912ef.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=asdf/20210118/us-east-1/s3/aws4_request&X-Amz-Date=20210118T155519Z&X-Amz-Expires=900&X-Amz-Signature=98143b79f47a524ec378e864e7ce265afbccb7f99a1a3da2cc0e91479602c119&X-Amz-SignedHeaders=host
+    uri: http://127.0.0.1:9000/scholarsphere-dev/cache/a702c6a0-23a2-45ff-810f-185bb22ab2b6.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=scholarsphere/20210303/us-east-1/s3/aws4_request&X-Amz-Date=20210303T200027Z&X-Amz-Expires=900&X-Amz-Signature=2909f6ce689cc790247995d920dbb1e4c1ba97fa1c7ee7ac766e56498597e019&X-Amz-SignedHeaders=host
     body:
       encoding: UTF-8
-      base64_string: image-content
+      base64_string: 'imagecontent'
     headers:
       User-Agent:
       - Faraday v1.0.1
@@ -87,13 +87,13 @@ http_interactions:
       Vary:
       - Origin
       X-Amz-Request-Id:
-      - 165B5E9CCE6E2B1C
+      - 1668ED8643D8A6A4
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Mon, 18 Jan 2021 15:55:19 GMT
+      - Wed, 03 Mar 2021 20:00:27 GMT
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Mon, 18 Jan 2021 15:55:19 GMT
+  recorded_at: Wed, 03 Mar 2021 20:00:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/scholarsphere/client/ingest_spec.rb
+++ b/spec/scholarsphere/client/ingest_spec.rb
@@ -9,30 +9,37 @@ RSpec.describe Scholarsphere::Client::Ingest do
     )
   end
 
-  let(:depositor) do
+  let(:metadata) do
     {
-      email: 'jxd21@psu.edu',
-      given_name: 'John',
-      surname: 'Doe',
-      psu_id: 'jxd21'
+      title: title,
+      creators_attributes: [creators]
     }
   end
 
-  let(:creator_alias) do
+  let(:depositor) do
     {
-      alias: 'John Doe',
+      psu_id: 'agw13',
+      surname: 'Wead',
+      given_name: 'Adam',
+      email: 'agw13@psu.edu'
+    }
+  end
+
+  let(:creators) do
+    {
+      display_name: 'Dan Coughlin',
       actor_attributes: {
-        email: 'jxd21@psu.edu',
-        given_name: 'John',
-        surname: 'Doe',
-        psu_id: 'jxd21'
+        psu_id: 'dmc186',
+        surname: 'Coughlin',
+        given_name: 'Dan',
+        email: 'dmc186@psu.edu'
       }
     }
   end
 
   describe '#publish', :vcr do
     context 'with an array of files' do
-      let(:metadata) { { title: 'Sample Title', creator_aliases_attributes: [creator_alias] } }
+      let(:title) { 'Sample Title' }
       let(:files) { [fixture_path('image.png'), fixture_path('ipsum.pdf')] }
 
       it 'publishes new works into Scholarsphere' do
@@ -43,7 +50,7 @@ RSpec.describe Scholarsphere::Client::Ingest do
     end
 
     context 'with an array of hashes specifying the deposit date' do
-      let(:metadata) { { title: 'Array of Hashes for Files', creator_aliases_attributes: [creator_alias] } }
+      let(:title) { 'Array of Hashes for Files' }
       let(:files) do
         [
           {

--- a/spec/scholarsphere/client_spec.rb
+++ b/spec/scholarsphere/client_spec.rb
@@ -10,6 +10,23 @@ RSpec.describe Scholarsphere::Client do
 
     it { is_expected.to be_a(Faraday::Connection) }
     its(:headers) { is_expected.to include('Content-Type' => 'application/json') }
-    its(:ssl) { is_expected.to be_verify }
+
+    context 'when verifying ssl' do
+      before do
+        described_class.reset
+        ENV['SS_CLIENT_SSL'] = 'true'
+      end
+
+      its(:ssl) { is_expected.to be_verify }
+    end
+
+    context 'when NOT verifying ssl' do
+      before do
+        described_class.reset
+        ENV['SS_CLIENT_SSL'] = 'false'
+      end
+
+      its(:ssl) { is_expected.not_to be_verify }
+    end
   end
 end


### PR DESCRIPTION
Scholarsphere 4.2 introduced some changes to the metadata schema which required some changes to the spec tests in order to reflect an accurate pairing between this client and the current Scholarsphere application.